### PR TITLE
*: support both runc and kata runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - lvm
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - lvm
     tags:
       - 'v*.*.*'
 

--- a/app/components/addInstanceModal.tsx
+++ b/app/components/addInstanceModal.tsx
@@ -12,6 +12,11 @@ enum Images {
   Ubuntu2004 = 'tispace/ubuntu2004',
 }
 
+enum Runtimes {
+  Kata = 'kata',
+  Runc = 'runc',
+}
+
 const layout = {
   labelCol: { span: 4 },
   wrapperCol: { span: 18 },
@@ -161,6 +166,21 @@ function AddInstanceModal({
               addonBefore={<ImFloppyDisk />}
               addonAfter="GiB"
             />
+          </Form.Item>
+          <Form.Item
+            name="runtime"
+            label="Runtime"
+            rules={[
+              {
+                required: true,
+                message: 'Please select an runtime!',
+              },
+            ]}
+          >
+            <Select>
+              <Select.Option value={Runtimes.Kata}>kata</Select.Option>
+              <Select.Option value={Runtimes.Runc}>runc</Select.Option>
+            </Select>
           </Form.Item>
         </Form>
       </Modal>

--- a/configs/cluster/kata-runtimeclass.yaml
+++ b/configs/cluster/kata-runtimeclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata
+handler: kata

--- a/configs/cluster/runc-runtimeclass.yaml
+++ b/configs/cluster/runc-runtimeclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runc
+handler: runc

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -8,13 +8,15 @@ crate struct CreateInstanceRequest {
     crate memory: usize,
     crate disk_size: usize,
     crate image: Option<String>,
+    crate runtime: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 crate struct UpdateInstanceRequest {
-    crate cpu: usize,
-    crate memory: usize,
+    crate cpu: Option<usize>,
+    crate memory: Option<usize>,
+    crate runtime: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -31,9 +33,10 @@ crate struct Instance {
     crate ssh_port: Option<i32>,
     crate password: String,
     crate status: String,
-    crate image: String,
+    crate image: Option<String>,
     crate internal_ip: Option<String>,
     crate external_ip: Option<String>,
+    crate runtime: Option<String>,
 }
 
 fn strip_image_tag(image: String) -> String {
@@ -56,9 +59,10 @@ impl From<&crate::model::Instance> for Instance {
             ssh_port: m.ssh_port,
             password: m.password.clone(),
             status: m.status.to_string(),
-            image: strip_image_tag(m.image.clone()),
+            image: m.image.clone().map(strip_image_tag),
             internal_ip: m.internal_ip.clone(),
             external_ip: m.external_ip.clone(),
+            runtime: m.runtime.clone(),
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,7 +49,7 @@ crate struct Instance {
     crate cpu: usize,
     crate memory: usize,
     crate disk_size: usize,
-    crate image: String,
+    crate image: Option<String>,
     crate hostname: String,
     // Deprecated: use external_ip instead.
     crate ssh_host: Option<String>,
@@ -60,6 +60,7 @@ crate struct Instance {
     crate status: InstanceStatus,
     crate internal_ip: Option<String>,
     crate external_ip: Option<String>,
+    crate runtime: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -32,24 +32,22 @@ static DEFAULT_RUNTIME_CLASS_NAME: Lazy<String> =
     Lazy::new(|| std::env::var("DEFAULT_RUNTIME_CLASS_NAME").unwrap_or_else(|_| "kata".to_owned()));
 static STORAGE_CLASS_NAME: Lazy<String> =
     Lazy::new(|| std::env::var("STORAGE_CLASS_NAME").unwrap_or_else(|_| "openebs-lvm".to_owned()));
-static DEFAULT_CONTAINER_CAPS: Lazy<Vec<String>> = Lazy::new(|| {
-    vec![
-        "CHOWN".to_owned(),
-        "DAC_OVERRIDE".to_owned(),
-        "FSETID".to_owned(),
-        "FOWNER".to_owned(),
-        "MKNOD".to_owned(),
-        "NET_RAW".to_owned(),
-        "SETGID".to_owned(),
-        "SETUID".to_owned(),
-        "SETFCAP".to_owned(),
-        "SETPCAP".to_owned(),
-        "NET_BIND_SERVICE".to_owned(),
-        "SYS_CHROOT".to_owned(),
-        "KILL".to_owned(),
-        "AUDIT_WRITE".to_owned(),
-    ]
-});
+const DEFAULT_CONTAINER_CAPS: [&str; 14] = [
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FSETID",
+    "FOWNER",
+    "MKNOD",
+    "NET_RAW",
+    "SETGID",
+    "SETUID",
+    "SETFCAP",
+    "SETPCAP",
+    "NET_BIND_SERVICE",
+    "SYS_CHROOT",
+    "KILL",
+    "AUDIT_WRITE",
+];
 
 fn append_image_tag_if_missing(mut image: String) -> String {
     if !image.contains(':') {
@@ -98,7 +96,12 @@ fn build_security_context(runtime: &str) -> SecurityContext {
         // But leave a least capabilities set to ensure systemd can run properly.
         SecurityContext {
             capabilities: Some(Capabilities {
-                add: Some(DEFAULT_CONTAINER_CAPS.clone()),
+                add: Some(
+                    DEFAULT_CONTAINER_CAPS
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()

--- a/src/service.rs
+++ b/src/service.rs
@@ -26,9 +26,9 @@ use crate::{
 
 static INSTANCE_NAME_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$").unwrap());
-static VERIFIED_ROOTFS_IMAGES: Lazy<Vec<&str>> =
-    Lazy::new(|| vec!["tispace/centos7", "tispace/centos8", "tispace/ubuntu2004"]);
-static SUPPORTED_RUNTIMES: Lazy<Vec<&str>> = Lazy::new(|| vec!["kata", "runc"]);
+const VERIFIED_ROOTFS_IMAGES: [&str; 3] =
+    ["tispace/centos7", "tispace/centos8", "tispace/ubuntu2004"];
+const SUPPORTED_RUNTIMES: [&str; 2] = ["kata", "runc"];
 
 /// Returns true if and only if the name is a valid instance name.
 ///

--- a/src/service.rs
+++ b/src/service.rs
@@ -26,13 +26,9 @@ use crate::{
 
 static INSTANCE_NAME_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$").unwrap());
-static DEFAULT_ROOTFS_IMAGE: Lazy<String> = Lazy::new(|| {
-    std::env::var("DEFAULT_ROOTFS_IMAGE").unwrap_or_else(|_| "tispace/centos7".to_owned())
-});
-static DEFAULT_ROOTFS_IMAGE_TAG: Lazy<String> =
-    Lazy::new(|| std::env::var("DEFAULT_ROOTFS_IMAGE_TAG").unwrap_or_else(|_| "latest".to_owned()));
 static VERIFIED_ROOTFS_IMAGES: Lazy<Vec<&str>> =
     Lazy::new(|| vec!["tispace/centos7", "tispace/centos8", "tispace/ubuntu2004"]);
+static SUPPORTED_RUNTIMES: Lazy<Vec<&str>> = Lazy::new(|| vec!["kata", "runc"]);
 
 /// Returns true if and only if the name is a valid instance name.
 ///
@@ -48,14 +44,6 @@ fn verify_instance_name(name: &str) -> bool {
 /// Currently we only support images which is in the list of verified images.
 fn is_verified_rootfs_image(image: &str) -> bool {
     VERIFIED_ROOTFS_IMAGES.iter().any(|&s| s == image)
-}
-
-fn append_image_tag_if_missing(mut image: String) -> String {
-    if !image.contains(':') {
-        image.push(':');
-        image.push_str(DEFAULT_ROOTFS_IMAGE_TAG.as_str());
-    }
-    image
 }
 
 pub fn protected_routes() -> Router {
@@ -79,6 +67,11 @@ pub fn protected_routes() -> Router {
         if let Some(image) = &req.image {
             if !is_verified_rootfs_image(image) {
                 return Err(InstanceError::ImageUnverified);
+            }
+        }
+        if let Some(runtime) = &req.runtime {
+            if !SUPPORTED_RUNTIMES.iter().any(|&s| s == runtime) {
+                return Err(InstanceError::InvalidArgs("runtime".to_string()));
             }
         }
         let mut user_err = None;
@@ -139,14 +132,9 @@ pub fn protected_routes() -> Router {
                             return false;
                         }
 
-                        let image = req
-                            .image
-                            .clone()
-                            .unwrap_or_else(|| DEFAULT_ROOTFS_IMAGE.to_owned());
-
                         u.instances.push(Instance {
                             name: req.name.clone(),
-                            image: append_image_tag_if_missing(image),
+                            image: req.image.clone(),
                             cpu: req.cpu,
                             memory: req.memory,
                             disk_size: req.disk_size,
@@ -162,6 +150,7 @@ pub fn protected_routes() -> Router {
                             status: InstanceStatus::Starting,
                             internal_ip: None,
                             external_ip: None,
+                            runtime: req.runtime.clone(),
                         });
                         true
                     }
@@ -234,11 +223,16 @@ pub fn protected_routes() -> Router {
         Json(req): Json<UpdateInstanceRequest>,
         Extension(storage): Extension<Storage>,
     ) -> Result<impl IntoResponse, InstanceError> {
-        if req.cpu == 0 {
+        if let Some(0) = req.cpu {
             return Err(InstanceError::InvalidArgs("cpu".to_string()));
         }
-        if req.memory == 0 {
+        if let Some(0) = req.memory {
             return Err(InstanceError::InvalidArgs("memory".to_string()));
+        }
+        if let Some(runtime) = &req.runtime {
+            if !SUPPORTED_RUNTIMES.iter().any(|&s| s == runtime) {
+                return Err(InstanceError::InvalidArgs("runtime".to_string()));
+            }
         }
         let mut user_err = None;
         match storage
@@ -267,28 +261,35 @@ pub fn protected_routes() -> Router {
                                     user_err = Some(InstanceError::NotYetStopped);
                                     return false;
                                 }
-                                if total_cpu + req.cpu > u.cpu_quota {
-                                    user_err = Some(InstanceError::QuotaExceeded {
-                                        resource: "CPU".to_string(),
-                                        quota: u.cpu_quota,
-                                        remaining: u.cpu_quota - total_cpu,
-                                        requested: req.cpu,
-                                        unit: "C".to_string(),
-                                    });
-                                    return false;
+                                if let Some(cpu) = req.cpu {
+                                    if total_cpu + cpu > u.cpu_quota {
+                                        user_err = Some(InstanceError::QuotaExceeded {
+                                            resource: "CPU".to_string(),
+                                            quota: u.cpu_quota,
+                                            remaining: u.cpu_quota - total_cpu,
+                                            requested: cpu,
+                                            unit: "C".to_string(),
+                                        });
+                                        return false;
+                                    }
+                                    instance.cpu = cpu;
                                 }
-                                if total_memory + req.memory > u.memory_quota {
-                                    user_err = Some(InstanceError::QuotaExceeded {
-                                        resource: "Memory".to_string(),
-                                        quota: u.memory_quota,
-                                        remaining: u.memory_quota - total_memory,
-                                        requested: req.memory,
-                                        unit: "GiB".to_string(),
-                                    });
-                                    return false;
+                                if let Some(memory) = req.memory {
+                                    if total_memory + memory > u.memory_quota {
+                                        user_err = Some(InstanceError::QuotaExceeded {
+                                            resource: "Memory".to_string(),
+                                            quota: u.memory_quota,
+                                            remaining: u.memory_quota - total_memory,
+                                            requested: memory,
+                                            unit: "GiB".to_string(),
+                                        });
+                                        return false;
+                                    }
+                                    instance.memory = memory;
                                 }
-                                instance.cpu = req.cpu;
-                                instance.memory = req.memory;
+                                if let Some(runtime) = &req.runtime {
+                                    instance.runtime = Some(runtime.to_owned());
+                                }
                                 true
                             }
                             None => false,
@@ -457,17 +458,5 @@ mod tests {
         assert!(is_verified_rootfs_image("tispace/centos8"));
         assert!(!is_verified_rootfs_image("jrei/systemd-ubuntu"));
         assert!(!is_verified_rootfs_image("jrei/systemd-centos"));
-    }
-
-    #[test]
-    fn test_append_image_tag_if_missing() {
-        assert_eq!(
-            append_image_tag_if_missing("tispace/ubuntu2004".to_owned()),
-            "tispace/ubuntu2004:latest".to_owned()
-        );
-        assert_eq!(
-            append_image_tag_if_missing("tispace/ubuntu2004:1.2.0".to_owned()),
-            "tispace/ubuntu2004:1.2.0".to_owned()
-        );
     }
 }


### PR DESCRIPTION
Kata container have poor IO performance even if we change our storage from Ceph RBD to local LVM storage. This is most likely because the overhead of the fuse.I think we can support both runc and kata runtime. And let user to choose what they need.

runc: better performance but less isolation and usability.
kata: better isolation and usability but with poor IO performance.
