### PR TITLE
service,operator: refinement for creating instances

### DIFF
--- a/src/dto.rs
+++ b/src/dto.rs
@@ -33,10 +33,10 @@ crate struct Instance {
     crate ssh_port: Option<i32>,
     crate password: String,
     crate status: String,
-    crate image: Option<String>,
+    crate image: String,
     crate internal_ip: Option<String>,
     crate external_ip: Option<String>,
-    crate runtime: Option<String>,
+    crate runtime: String,
 }
 
 fn strip_image_tag(image: String) -> String {
@@ -59,7 +59,7 @@ impl From<&crate::model::Instance> for Instance {
             ssh_port: m.ssh_port,
             password: m.password.clone(),
             status: m.status.to_string(),
-            image: m.image.clone().map(strip_image_tag),
+            image: strip_image_tag(m.image.clone()),
             internal_ip: m.internal_ip.clone(),
             external_ip: m.external_ip.clone(),
             runtime: m.runtime.clone(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,7 +49,7 @@ crate struct Instance {
     crate cpu: usize,
     crate memory: usize,
     crate disk_size: usize,
-    crate image: Option<String>,
+    crate image: String,
     crate hostname: String,
     // Deprecated: use external_ip instead.
     crate ssh_host: Option<String>,
@@ -60,7 +60,7 @@ crate struct Instance {
     crate status: InstanceStatus,
     crate internal_ip: Option<String>,
     crate external_ip: Option<String>,
-    crate runtime: Option<String>,
+    crate runtime: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -414,7 +414,7 @@ impl Operator {
         let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(self.client.clone(), NAMESPACE);
         match pvcs.delete(pvc_name, &DeleteParams::default()).await {
             Ok(Either::Left(_)) => {
-                info!("deleting serpersistentvolumeclaimvice {}", pvc_name);
+                info!("deleting persistentvolumeclaim {}", pvc_name);
                 Ok(())
             }
             Ok(Either::Right(_)) => {


### PR DESCRIPTION
This PR made some refinements for creating instances.

* Change `Instance.image` and `Instance.runtime` from `Option<String>` to `String`, and always set the default value in service.
* ~~Add `disk_name` to `Instance`. It will be convenient to migrate disk data across nodes.~~ (We should use label selector instead.)