### PR TITLE
*: initial framework for lxd

### DIFF
--- a/app/components/addInstanceModal.tsx
+++ b/app/components/addInstanceModal.tsx
@@ -47,7 +47,7 @@ function AddInstanceModal({
             cpu: 8,
             memory: 16,
             disk_size: 80,
-            image: Images.Centos7,
+            image: Images.CentOS7,
             runtime: Runtimes.Kata,
           }}
         >
@@ -76,9 +76,9 @@ function AddInstanceModal({
             ]}
           >
             <Select>
-              <Select.Option value={Images.Centos7}>centos7</Select.Option>
+              <Select.Option value={Images.CentOS7}>centos:7</Select.Option>
               <Select.Option value={Images.Ubuntu2004}>
-                ubuntu2004
+                ubuntu:20.04
               </Select.Option>
             </Select>
           </Form.Item>

--- a/app/components/instance.tsx
+++ b/app/components/instance.tsx
@@ -1,11 +1,14 @@
 export enum Images {
-  Centos7 = 'tispace/centos7',
-  Ubuntu2004 = 'tispace/ubuntu2004',
+  CentOS7 = 'centos:7',
+  Ubuntu2004 = 'ubuntu:20.04',
+  Ubuntu2204 = 'ubuntu:22.04'
 }
 
 export enum Runtimes {
   Kata = 'kata',
   Runc = 'runc',
+  Lxc = 'lxc',
+  Kvm = 'kvm',
 }
 
 // See: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -242,13 +242,6 @@ const Home: NextPage = () => {
       title: 'Image',
       dataIndex: 'image',
       key: 'image',
-      render: (image) => {
-        return (
-          <a href={`https://hub.docker.com/r/${image}`}>
-            <Tag color="blue">{image}</Tag>
-          </a>
-        )
-      },
     },
     {
       title: 'Hostname',

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -7,8 +7,8 @@ crate struct CreateInstanceRequest {
     crate cpu: usize,
     crate memory: usize,
     crate disk_size: usize,
-    crate image: Option<String>,
-    crate runtime: Option<String>,
+    crate image: String,
+    crate runtime: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -39,14 +39,6 @@ crate struct Instance {
     crate runtime: String,
 }
 
-fn strip_image_tag(image: String) -> String {
-    if let Some(i) = image.rfind(':') {
-        image[..i].to_string()
-    } else {
-        image
-    }
-}
-
 impl From<&crate::model::Instance> for Instance {
     fn from(m: &crate::model::Instance) -> Self {
         Instance {
@@ -59,10 +51,10 @@ impl From<&crate::model::Instance> for Instance {
             ssh_port: m.ssh_port,
             password: m.password.clone(),
             status: m.status.to_string(),
-            image: strip_image_tag(m.image.clone()),
+            image: m.image.to_string(),
             internal_ip: m.internal_ip.clone(),
             external_ip: m.external_ip.clone(),
-            runtime: m.runtime.clone(),
+            runtime: m.runtime.to_string(),
         }
     }
 }
@@ -71,25 +63,4 @@ impl From<&crate::model::Instance> for Instance {
 #[serde(default)]
 crate struct ListInstancesResponse {
     crate instances: Vec<Instance>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_strip_image_tag() {
-        assert_eq!(
-            strip_image_tag("tispace/ubuntu2004".to_owned()),
-            "tispace/ubuntu2004".to_owned()
-        );
-        assert_eq!(
-            strip_image_tag("tispace/ubuntu2004:latest".to_owned()),
-            "tispace/ubuntu2004".to_owned()
-        );
-        assert_eq!(
-            strip_image_tag("tispace/ubuntu2004:1.2.0".to_owned()),
-            "tispace/ubuntu2004".to_owned()
-        );
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,8 +60,10 @@ crate enum InstanceError {
     StartFailed,
     #[error("Stop instance failed")]
     StopFailed,
-    #[error("Image is unverified")]
-    ImageUnverified,
+    #[error("Unsupported image")]
+    UnsupportedImage,
+    #[error("Unsupported runtime")]
+    UnsupportedRuntime,
 }
 
 impl IntoResponse for InstanceError {
@@ -80,7 +82,9 @@ impl IntoResponse for InstanceError {
             | InstanceError::UpdateFailed
             | InstanceError::StartFailed
             | InstanceError::StopFailed => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
-            InstanceError::ImageUnverified => (StatusCode::BAD_REQUEST, self.to_string()),
+            InstanceError::UnsupportedImage | InstanceError::UnsupportedRuntime => {
+                (StatusCode::BAD_REQUEST, self.to_string())
+            }
         };
         let body = Json(json!({
             "error": error_message,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod auth;
 mod dto;
 pub mod error;
 mod model;
-pub mod operator;
+pub mod operator_k8s;
+pub mod operator_lxd;
 pub mod service;
 pub mod storage;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,9 @@
-use std::fmt;
 use std::fmt::Formatter;
+use std::{fmt, str::FromStr};
 
-use serde::{Deserialize, Serialize};
+use crate::error::InstanceError;
+use serde::de::Error as SerdeError;
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 crate enum InstanceStage {
@@ -43,13 +45,132 @@ impl fmt::Display for InstanceStatus {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Eq, PartialEq)]
+crate enum Runtime {
+    Kata,
+    Runc,
+    Lxc,
+    Kvm,
+}
+
+impl fmt::Display for Runtime {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Runtime::Kata => write!(f, "kata"),
+            Runtime::Runc => write!(f, "runc"),
+            Runtime::Lxc => write!(f, "lxc"),
+            Runtime::Kvm => write!(f, "kvm"),
+        }
+    }
+}
+
+impl FromStr for Runtime {
+    type Err = InstanceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_ascii_lowercase();
+        match lower.as_str() {
+            "kata" => Ok(Self::Kata),
+            "runc" => Ok(Self::Runc),
+            "lxc" => Ok(Self::Lxc),
+            "kvm" => Ok(Self::Kvm),
+            _ => Err(InstanceError::UnsupportedRuntime),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Runtime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        Runtime::from_str(&s).map_err(|_| SerdeError::custom(format!("invalid runtime {}", s)))
+    }
+}
+
+impl Runtime {
+    crate fn supported_images(&self) -> Vec<Image> {
+        match self {
+            Runtime::Kata => vec![Image::CentOS7, Image::Ubuntu2004],
+            Runtime::Runc => vec![Image::CentOS7, Image::Ubuntu2004],
+            Runtime::Lxc => vec![Image::CentOS7, Image::Ubuntu2004, Image::Ubuntu2204],
+            Runtime::Kvm => vec![Image::CentOS7, Image::Ubuntu2004, Image::Ubuntu2204],
+        }
+    }
+
+    crate fn compatiable_with(&self, other: &Runtime) -> bool {
+        matches!(
+            (self, other),
+            (Runtime::Kata, Runtime::Kata)
+                | (Runtime::Kata, Runtime::Runc)
+                | (Runtime::Runc, Runtime::Kata)
+                | (Runtime::Runc, Runtime::Runc)
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Eq, PartialEq)]
+crate enum Image {
+    CentOS7,
+    CentOS8,
+    Ubuntu2004,
+    Ubuntu2204,
+}
+
+impl fmt::Display for Image {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Image::CentOS7 => write!(f, "centos:7"),
+            Image::CentOS8 => write!(f, "centos:8"),
+            Image::Ubuntu2004 => write!(f, "ubuntu:20.04"),
+            Image::Ubuntu2204 => write!(f, "ubuntu:22.04"),
+        }
+    }
+}
+
+impl FromStr for Image {
+    type Err = InstanceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let lower = s.to_lowercase();
+        if lower.starts_with("tispace/centos7:") {
+            return Ok(Self::CentOS7);
+        }
+        if lower.starts_with("tispace/centos8:") {
+            return Ok(Self::CentOS8);
+        }
+        if lower.starts_with("tispace/ubuntu2004:") {
+            return Ok(Self::Ubuntu2004);
+        }
+        return match lower.as_str() {
+            "tispace/centos7" | "centos7" | "centos:7" => Ok(Self::CentOS7),
+            "tispace/centos8" | "centos8" | "centos:8" => Ok(Self::CentOS8),
+            "tispace/ubuntu2004" | "ubuntu2004" | "ubuntu:20.04" => Ok(Self::Ubuntu2004),
+            "ubuntu:22.04" => Ok(Self::Ubuntu2204),
+            _ => Err(InstanceError::UnsupportedImage),
+        };
+    }
+}
+
+impl<'de> Deserialize<'de> for Image {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Image::from_str(&s).map_err(|_| SerdeError::custom(format!("invalid image {}", s)))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 crate struct Instance {
     crate name: String,
     crate cpu: usize,
     crate memory: usize,
     crate disk_size: usize,
-    crate image: String,
+    crate image: Image,
     crate hostname: String,
     // Deprecated: use external_ip instead.
     crate ssh_host: Option<String>,
@@ -60,7 +181,7 @@ crate struct Instance {
     crate status: InstanceStatus,
     crate internal_ip: Option<String>,
     crate external_ip: Option<String>,
-    crate runtime: String,
+    crate runtime: Runtime,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/operator_lxd.rs
+++ b/src/operator_lxd.rs
@@ -1,0 +1,13 @@
+use crate::storage::Storage;
+
+pub struct Operator {
+    _storage: Storage,
+}
+
+impl Operator {
+    pub fn new(storage: Storage) -> Self {
+        Operator { _storage: storage }
+    }
+
+    pub async fn run(&self) {}
+}


### PR DESCRIPTION
* Refine model runtime to enum and support `lxc` and `kvm`.
* Refine model image to enum and don't associate with docker image.
* Add an initial operator for lxd.