### PR TITLE
scheduler: schedule node for runc/kata runtime before creating

### DIFF
--- a/src/operator_k8s.rs
+++ b/src/operator_k8s.rs
@@ -329,6 +329,10 @@ impl Operator {
                     if instance.runtime != Runtime::Kata && instance.runtime != Runtime::Runc {
                         continue;
                     }
+                    // Wait for the scheduler to assign a node to the instance.
+                    if instance.status == InstanceStatus::Creating && instance.node_name.is_none() {
+                        continue;
+                    }
                     self.sync_instance(user, instance).await;
                 }
                 // If a user has no instance, delete the Service.

--- a/src/operator_lxd.rs
+++ b/src/operator_lxd.rs
@@ -31,7 +31,7 @@ impl Operator {
                 if instance.runtime != Runtime::Lxc && instance.runtime != Runtime::Kvm {
                     continue;
                 }
-                // Wait scheduler to allocate an IP address and schedule node and storage pool for this instance.
+                // Wait for the scheduler to allocate an IP address and schedule node and storage pool for this instance.
                 if instance.status == InstanceStatus::Creating
                     && (instance.external_ip.is_none()
                         || instance.node_name.is_none()


### PR DESCRIPTION
K8s operator and LXD operator create instances on the same nodes. K8s operator lets K8s scheduler to schedule node for each instance automatically. However,  K8s scheduler is unaware of the lxd intances, which may result in an unbalanced distribution of instances across the nodes.